### PR TITLE
Add GitHub Actions workflow for web export

### DIFF
--- a/.github/workflows/web-export.yml
+++ b/.github/workflows/web-export.yml
@@ -1,0 +1,32 @@
+name: Web Export
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build web app
+        run: npm run export:web
+
+      - name: Upload web build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: web-build
+          path: dist/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "format": "prettier --write .",
     "check-updates": "npx npm-check-updates",
     "tsc": "tsc --noEmit",
-    "lint:fix": "eslint . --ext .ts,.tsx --fix"
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "profile:web": "expo build:web --no-minify --output dist --source-map",
+    "export:web": "expo export -p web --output dist --source-map --no-minify"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",


### PR DESCRIPTION
Add GitHub Actions workflow for exporting the website as a web app and saving artifacts.

* **.github/workflows/web-export.yml**
  - Add a new GitHub Actions workflow file to export the website as a web app and save the artifacts.
  - Configure the workflow to run on push and pull request events.
  - Include steps to check out the repository, set up Node.js, install dependencies, build the web app, and upload the build artifacts.

* **package.json**
  - Add `profile:web` script with the command `expo build:web --no-minify --output dist --source-map`.
  - Add `export:web` script with the command `expo export -p web --output dist --source-map --no-minify`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ueff24/ueff-app-expo/pull/9?shareId=68b0db0e-915b-4f2b-874f-8f5579c32251).