### PR TITLE
Improve EAS build process with manual control and prebuild step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   build:
@@ -19,6 +20,9 @@ jobs:
         with:
           node-version: '23'
 
+      - name: Expo Prebuild
+        run: expo prebuild
+
       - name: Install dependencies
         run: npm install
 
@@ -31,6 +35,6 @@ jobs:
           EXPO_TOKEN=${{ secrets.EXPO_TOKEN }} eas build --profile production --platform android --non-interactive
 
       - name: EAS Build for PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'eas-build')
         run: |
           EXPO_TOKEN=${{ secrets.EXPO_TOKEN }} eas build --profile development --platform android --non-interactive

--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ To use EAS (Expo Application Services) build, follow these steps:
    ```
 
 4. Monitor your build on the [Expo dashboard](https://expo.dev/accounts/your-username/projects/your-project/builds).
+
+## Triggering EAS Build with `eas-build` Tag
+
+To trigger an EAS build manually with the `eas-build` tag on a pull request, follow these steps:
+
+1. Create a pull request.
+2. Add the `eas-build` tag to the pull request.
+3. The EAS build will be triggered automatically when the tag is added.
+
+## Running `expo prebuild` in the Pipeline
+
+To run `expo prebuild` in the pipeline, ensure that the `expo prebuild` step is added before the `Install dependencies` step in the GitHub Actions workflow file `.github/workflows/build.yml`.


### PR DESCRIPTION
Add instructions and conditions for EAS build and expo prebuild in README and GitHub Actions workflow.

* **README.md**
  - Add instructions to trigger EAS build with `eas-build` tag.
  - Add instructions to run `expo prebuild` in the pipeline.

* **.github/workflows/build.yml**
  - Add a condition to check for `eas-build` tag on PR.
  - Add `expo prebuild` step before `Install dependencies` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Ueff24/ueff-app-expo/pull/10?shareId=006928f3-6cc4-4fcb-ba8c-5a4adddf9c44).